### PR TITLE
Disable default simplify in postprocess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### Deprecations and compatibility notes
 
-- 
+- Disable default simplify in postprocess (#32)
 
 ## 0.3.0 (2022-02-10)
 

--- a/orthoseg/project_defaults.ini
+++ b/orthoseg/project_defaults.ini
@@ -285,7 +285,7 @@ dissolve_tiles_path
 
 # Apply simplify (also) after dissolve. For more information, check out the 
 # documentation at parameter predict:simplify_algorithm
-simplify_algorithm = LANG
+simplify_algorithm
 
 # Tolerance to use for the postprocess simplification. 
 # Remark: you can use simple math expressions, eg. 1.5*5 


### PR DESCRIPTION
The inline simplify is the default to use, because it can apply topologic simplify. The postprocess simplify can do this as well in theory, but on larger output files this won't work in practice (at the moment).