### PR TITLE
Support newer versions of used packages

### DIFF
--- a/orthoseg/lib/postprocess_predictions.py
+++ b/orthoseg/lib/postprocess_predictions.py
@@ -11,7 +11,7 @@ from typing import List, Optional
 
 # Evade having many info warnings about self intersections from shapely
 import geofileops as gfo
-from geofileops.util import geoseries_util as gfo_geoseries_util
+from geofileops.util import geoseries_util
 import geopandas as gpd
 import numpy as np
 import rasterio as rio
@@ -787,7 +787,7 @@ def polygonize_pred_multiclass(
                     keep_points_on=border_lines,
                 )
             else:
-                result_gdf.geometry = gfo_geoseries_util.simplify_ext(
+                result_gdf.geometry = geoseries_util.simplify_ext(
                     geoseries=result_gdf.geometry,
                     algorithm=simplify["simplify_algorithm"],
                     tolerance=simplify["simplify_tolerance"],

--- a/orthoseg/util/ows_util.py
+++ b/orthoseg/util/ows_util.py
@@ -1062,7 +1062,7 @@ def _get_cleaned_write_profile(
         # Don't copy profile keys to cleaned version that are not supported for JPEG
         profile_cleaned = {}
         for profile_key in profile:
-            if profile_key not in ["tiled", "interleave"]:
+            if profile_key not in ["tiled", "interleave", "blockxsize", "blockysize"]:
                 profile_cleaned[profile_key] = profile[profile_key]
     else:
         profile_cleaned = profile.copy()

--- a/orthoseg/util/vector_util.py
+++ b/orthoseg/util/vector_util.py
@@ -8,8 +8,8 @@ import logging
 from typing import Optional, Tuple
 
 import geofileops as gfo
-from geofileops import geometry_util
-from geofileops import geoseries_util
+from geofileops.util import geometry_util
+from geofileops.util import geoseries_util
 import geopandas as gpd
 import pandas as pd
 import pygeos

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setuptools.setup(
             orthoseg_train=orthoseg.train:main
             orthoseg_predict=orthoseg.predict:main
             orthoseg_postprocess=orthoseg.postprocess:main
-            scriptrunner=orthoseg.scriptrunner:main
+            osscriptrunner=orthoseg.scriptrunner:main
             orthoseg_load_sampleprojects=orthoseg.load_sampleprojects:main
             """,
     classifiers=[


### PR DESCRIPTION
- deprecation warnings in geofileops 0.4+
- new warnings when writing png in rasterio
- scriptrunner is now also a default command line tool in Windows, so change command to osscriptrunner