### PR TITLE
Fix reclassify_to_neighbours when some reclassification candidates are neighbours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@
 
 ### Bugs fixed
 
-- Fix non blocking errors in prediction being ignored/not reported + format error email in html (#72, #76)
 - Fix occasional errors when predicting with topologic simplify (#69)
+- Fix non blocking errors in prediction being ignored/not reported + format error email in html (#72, #76)
 - Fix error in prediction on ubuntu 22.04 (#73)
 - Fix error when prediction output dir doesn't exist yet (#75)
+- Fix reclassify_to_neighbours giving undetermined result when 2+ neighbours are reclassification candidates (#84)
 
 ### Deprecations and compatibility notes
 

--- a/tests/test_vector_util.py
+++ b/tests/test_vector_util.py
@@ -92,32 +92,46 @@ def test_reclassify_neighbours():
         ["Empty1", "Polygon EMPTY", "disappears", sh_geom.Polygon(), "class_1"],
         [
             "poly1",
-            "large polygon (100m²)",
-            "merged with some smaller polygons",
-            sh_geom.Polygon(shell=[(5, 5), (10, 5), (10, 15), (5, 15), (5, 5)]),
-            "class_large",
+            "large polygon (25m²)",
+            "smaller polygons are added to it",
+            sh_geom.Polygon(shell=[(5, 5), (10, 5), (10, 10), (5, 10), (5, 5)]),
+            "class_1_large",
         ],
         [
             "poly2",
-            "neighbour of polygon1, small (5m²), onborder",
+            "medium (5m²), neighbour of polygon1, onborder",
             "is onborder, so isn't merged with other things",
             sh_geom.Polygon(shell=[(0, 5), (0, 6), (5, 6), (5, 5), (0, 5)]),
-            "class_small2",
+            "class_2_medium",
         ],
         [
             "poly3",
             "neighbour of polygon1, small (1m²), not onborder",
             "is merged with poly1",
             sh_geom.Polygon(shell=[(10, 5), (11, 5), (11, 6), (10, 6), (10, 5)]),
-            "class_small3",
+            "class_3_small",
         ],
         [
             "poly4",
             "neighbour of poly3, small (1m²), not onborder",
             "is merged with poly1 and poly3",
             sh_geom.Polygon(shell=[(11, 5), (12, 5), (12, 6), (11, 6), (11, 5)]),
-            "class_small4",
+            "class_4_small",
         ],
+        [
+            "poly5",
+            "medium polygon (5m²), larger than neighbour poly6, not onborder",
+            "is merged with poly6 but retains class",
+            sh_geom.Polygon(shell=[(5, 15), (10, 15), (10, 16), (5, 16), (5, 15)]),
+            "class_5_medium",
+        ],
+        [
+            "poly6",
+            "small (1m²), smaller than neighbour poly5, not onborder",
+            "is merged with poly6 and gets its class",
+            sh_geom.Polygon(shell=[(4, 15), (5, 15), (5, 16), (4, 16), (4, 15)]),
+            "class_6_small",
+        ]
     ]
     df = pd.DataFrame(testdata, columns=columns)
     testdata_gdf = gpd.GeoDataFrame(df, geometry="geometry")  # type: ignore
@@ -125,10 +139,13 @@ def test_reclassify_neighbours():
     testdata_gdf = testdata_gdf.drop([2], axis=0)
 
     expected_result_df = pd.DataFrame(
-        [["poly1, poly3, poly4", "class_large"], ["poly2", "class_small2"]],
+        [
+            ["poly1, poly3, poly4", "class_1_large"],
+            ["poly2", "class_2_medium"],
+            ["poly5, poly6", "class_5_medium"],
+        ],
         columns=["test_id", reclassify_column],
     )
-
     # Test with extra column, values are concatenated
     # -----------------------------------------------
     # reclassify only supported on gdf with only the reclassify column
@@ -138,7 +155,6 @@ def test_reclassify_neighbours():
         testdata_prepared_gdf, reclassify_column, query, border_bounds
     )
     assert result_gdf is not None
-    assert len(result_gdf) == 2
     result_df = pd.DataFrame(result_gdf[["test_id", reclassify_column]])
     assert_frame_equal(result_df, expected_result_df)
 
@@ -153,7 +169,6 @@ def test_reclassify_neighbours():
         testdata_prepared_gdf, reclassify_column, query, border_bounds
     )
     assert result_gdf is not None
-    assert len(result_gdf) == 2
     result_df = pd.DataFrame(result_gdf[[reclassify_column]])
     assert_frame_equal(result_df, expected_result_df)
 


### PR DESCRIPTION
When multiple kandidate features for reclassification are neighbours, it is not determined which class will be retained. Better to always retain the class of the one with the largest area. 