### PR TITLE
Add option to specify reclassify to neighbour query as postprocessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Avoid warning blockysize is not supported for jpeg when downloading images (#77)
 - Add __version__ attribute to orthoseg (#80)
+- Add option to specify reclassify to neighbour query as postprocessing (#86)
 - Reuse sample_project for tests so it is tested as well (#81)
 - Improve test coverage (#79, #82, #83)
 

--- a/orthoseg/helpers/vectorfile_helper.py
+++ b/orthoseg/helpers/vectorfile_helper.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""
+Modile with generic Utility functions for vectorfile manipulations.
+"""
+
+import logging
+from pathlib import Path
+
+import geofileops as gfo
+
+from orthoseg.util import vector_util
+
+# -------------------------------------------------------------
+# First define/init some general variables/constants
+# -------------------------------------------------------------
+logger = logging.getLogger(__name__)
+# logger.setLevel(logging.DEBUG)
+
+# -------------------------------------------------------------
+# The real work
+# -------------------------------------------------------------
+
+
+def reclassify_neighbours(
+    input_path: Path,
+    reclassify_column: str,
+    query: str,
+    output_path: Path,
+    class_background: str = "background",
+):
+    """
+    For features that comply to the query, if they have a neighbour (touch/overlap),
+    change their classname to that of the neighbour with the longest intersection and
+    dissolve to merge them.
+
+    The query should follow the syntax of pandas.query queries and can us the following
+    fields:
+        - area (float): the area of the geometry.
+        - perimeter (float): the perimeter of the geometry.
+
+    Args:
+        gdf (gpd.GeoDataFrame): input
+        reclassify_column (str): column to reclassify.
+        query (str): th query to find the features to reclassify.
+        class_background (str, optional): the classname to treat as background.
+            Defaults to "background".
+
+    Raises:
+        ValueError: raised if incompatible parameters are passed.
+    """
+    logger.info("start reclassify_neighbours")
+    input_gdf = gfo.read_file(input_path, columns=[reclassify_column])
+    output_gdf = vector_util.reclassify_neighbours(
+        input_gdf,
+        reclassify_column=reclassify_column,
+        query=query,
+        border_bounds=None,
+        class_background=class_background,
+    )
+    gfo.to_file(output_gdf, output_path)
+
+    # Add/recalculate columns with area and nbcoords
+    gfo.add_column(
+        path=output_path,
+        name="area",
+        type=gfo.DataType.REAL,
+        expression="ST_Area(geom)",
+        force_update=True,
+    )
+    gfo.add_column(
+        path=output_path,
+        name="nbcoords",
+        type=gfo.DataType.INTEGER,
+        expression="ST_NPoints(geom)",
+        force_update=True,
+    )

--- a/orthoseg/lib/postprocess_predictions.py
+++ b/orthoseg/lib/postprocess_predictions.py
@@ -23,6 +23,7 @@ import shapely.geometry as sh_geom
 import tensorflow as tf
 
 from orthoseg.util import vector_util
+from orthoseg.helpers import vectorfile_helper
 
 
 logging.getLogger("shapely.geos").setLevel(logging.WARNING)
@@ -133,32 +134,12 @@ def postprocess_predictions(
         curr_output_path = (
             output_path.parent / f"{output_path.stem}_reclass{output_path.suffix}"
         )
-        logger.info("start reclassify_neighbours")
-        input_gdf = gfo.read_file(curr_input_path, columns=["classname"])
-        output_gdf = vector_util.reclassify_neighbours(
-            input_gdf,
+        vectorfile_helper.reclassify_neighbours(
+            input_path=curr_input_path,
             reclassify_column="classname",
             query=reclassify_to_neighbour_query,
-            border_bounds=None,
+            output_path=output_path,
         )
-        gfo.to_file(output_gdf, curr_output_path)
-
-        # Add/recalculate columns with area and nbcoords
-        gfo.add_column(
-            path=curr_output_path,
-            name="area",
-            type=gfo.DataType.REAL,
-            expression="ST_Area(geom)",
-            force_update=True,
-        )
-        gfo.add_column(
-            path=curr_output_path,
-            name="nbcoords",
-            type=gfo.DataType.INTEGER,
-            expression="ST_NPoints(geom)",
-            force_update=True,
-        )
-
         curr_input_path = curr_output_path
         output_paths.append(curr_output_path)
 

--- a/orthoseg/postprocess.py
+++ b/orthoseg/postprocess.py
@@ -126,6 +126,10 @@ def postprocess(config_path: Path):
 
         dissolve = conf.postprocess.getboolean("dissolve")
         dissolve_tiles_path = conf.postprocess.getpath("dissolve_tiles_path")
+        reclassify_query = conf.postprocess.get("reclassify_to_neighbour_query")
+        if reclassify_query is not None:
+            reclassify_query = reclassify_query.replace("\n", " ")
+
         simplify_algorithm = conf.postprocess.get("simplify_algorithm")
         if simplify_algorithm is not None:
             simplify_algorithm = gfo.SimplifyAlgorithm[simplify_algorithm]
@@ -140,6 +144,7 @@ def postprocess(config_path: Path):
             output_path=output_vector_path,
             dissolve=dissolve,
             dissolve_tiles_path=dissolve_tiles_path,
+            reclassify_to_neighbour_query=reclassify_query,
             simplify_algorithm=simplify_algorithm,
             simplify_tolerance=simplify_tolerance,
             simplify_lookahead=simplify_lookahead,

--- a/orthoseg/project_defaults.ini
+++ b/orthoseg/project_defaults.ini
@@ -294,6 +294,15 @@ dissolve = True
 # provided.
 dissolve_tiles_path
 
+# Reclassify all detected polygons that comply to the query provided to the class of
+# the neighbour with the longest border with it.
+# The query need to be in the form to be used by pandas.DataFrame.query() and the
+# following columns are available to query on:
+#   - area: the area of the polygon, as calculated by GeoSeries.area.
+#   - perimeter: the perimeter of the polygon, as calculated by GeoSeries.length.
+# Eg.: reclassify_to_neighbour_query = (area <= 5)
+reclassify_to_neighbour_query
+
 # Apply simplify (also) after dissolve. For more information, check out the 
 # documentation at parameter predict:simplify_algorithm
 simplify_algorithm

--- a/tests/test_vectorfile_helper.py
+++ b/tests/test_vectorfile_helper.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for functionalities in orthoseg.lib.postprocess_predictions.
+"""
+import os
+from pathlib import Path
+import sys
+
+import geopandas as gpd
+import geofileops as gfo
+import pandas as pd
+from shapely import geometry as sh_geom
+
+# Make hdf5 version warning non-blocking
+os.environ["HDF5_DISABLE_VERSION_CHECK"] = "1"
+
+# Add path so the local orthoseg packages are found
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from orthoseg.helpers import vectorfile_helper
+
+
+def test_reclassify_neighbours(tmp_path):
+    # Prepare test data
+    reclassify_column = "class_name"
+    query = "area <= 20"
+    columns = ["test_id", "descr", "expected_result", "geometry", reclassify_column]
+    testdata = [
+        ["None1", "Geom None", "disappears", None, "class_1"],
+        ["None2", "Geom None", "disappears", None, "class_1"],
+        ["None3", "to be removed", "disappears", None, "class_1"],
+        ["Empty1", "Polygon EMPTY", "disappears", sh_geom.Polygon(), "class_1"],
+        [
+            "poly1",
+            "large polygon (25m²)",
+            "smaller polygons are added to it",
+            sh_geom.Polygon(shell=[(5, 5), (10, 5), (10, 10), (5, 10), (5, 5)]),
+            "class_1_large",
+        ],
+        [
+            "poly2",
+            "medium (5m²), neighbour of polygon1, onborder",
+            "is onborder, so isn't merged with other things",
+            sh_geom.Polygon(shell=[(0, 5), (0, 6), (5, 6), (5, 5), (0, 5)]),
+            "class_2_medium",
+        ],
+        [
+            "poly3",
+            "neighbour of polygon1, small (1m²), not onborder",
+            "is merged with poly1",
+            sh_geom.Polygon(shell=[(10, 5), (11, 5), (11, 6), (10, 6), (10, 5)]),
+            "class_3_small",
+        ],
+        [
+            "poly4",
+            "neighbour of poly3, small (1m²), not onborder",
+            "is merged with poly1 and poly3",
+            sh_geom.Polygon(shell=[(11, 5), (12, 5), (12, 6), (11, 6), (11, 5)]),
+            "class_4_small",
+        ],
+        [
+            "poly5",
+            "medium polygon (5m²), larger than neighbour poly6, not onborder",
+            "is merged with poly6 but retains class",
+            sh_geom.Polygon(shell=[(5, 15), (10, 15), (10, 16), (5, 16), (5, 15)]),
+            "class_5_medium",
+        ],
+        [
+            "poly6",
+            "small (1m²), smaller than neighbour poly5, not onborder",
+            "is merged with poly6 and gets its class",
+            sh_geom.Polygon(shell=[(4, 15), (5, 15), (5, 16), (4, 16), (4, 15)]),
+            "class_6_small",
+        ]
+    ]
+    df = pd.DataFrame(testdata, columns=columns)
+    testdata_gdf = gpd.GeoDataFrame(df, geometry="geometry")  # type: ignore
+    # Remove a row to test if the index is properly maintained
+    testdata_gdf = testdata_gdf.drop([2], axis=0)
+    testdata_path = tmp_path / "testdata.gpkg"
+    gfo.to_file(testdata_gdf, testdata_path)
+
+    # Test
+    result_path = tmp_path / "result.gpkg"
+    vectorfile_helper.reclassify_neighbours(
+        input_path=testdata_path,
+        reclassify_column=reclassify_column, query=query, output_path=result_path
+    )
+    result_gdf = gfo.read_file(result_path)
+    assert result_gdf is not None
+    assert len(result_gdf) == 2
+    assert reclassify_column in result_gdf.columns
+    assert "area" in result_gdf.columns
+    assert "nbcoords" in result_gdf.columns


### PR DESCRIPTION
After applying the reclassify during prediction, there can still be some eg. small pieces present because they were on the border. Using the reclassify in postprocessing cleans up these cases.

Remark: the reclassify_query now needs to be defined twice + slightly different both times which isn't a nice solution... should be improved -> #87 