### PR TITLE
Add check that train and validation data is mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Improve performance of prepare_traindatasets for large label files (#116)
+- Add check that train and validation data is mandatory (#118)
 
 ### Bugs fixed
 

--- a/orthoseg/lib/prepare_traindatasets.py
+++ b/orthoseg/lib/prepare_traindatasets.py
@@ -513,8 +513,8 @@ def prepare_labeldata(
             if intersection.area < (location_geom_aligned.area - area_1row_1col):
                 # Original geom was digitized too small
                 errors_found.append(
-                    f"Location geometry too small in {Path(location.path).name}: "
-                    f"{location.geometry.wkt}"
+                    "Location geometry skewed or too small in "
+                    f"{Path(location.path).name}: {location.geometry.wkt}"
                 )
             elif location_geom_aligned.area > 1.1 * sh_geom.box(*geom_bounds).area:
                 logger.warn(

--- a/orthoseg/lib/prepare_traindatasets.py
+++ b/orthoseg/lib/prepare_traindatasets.py
@@ -284,7 +284,6 @@ def prepare_traindatasets(
                 created_images_gdf["geometry"] = None
                 wms_imagelayer_layersources = {}
                 for i, label_tuple in enumerate(labellocations_curr_gdf.itertuples()):
-
                     img_bbox = label_tuple.geometry
                     image_layer = getattr(label_tuple, "image_layer")
 
@@ -536,6 +535,18 @@ def prepare_labeldata(
                 f"{labellocations_gdf.crs}"
             )
 
+        # Check that there is at least one train location and one validation location.
+        if len(labellocations_gdf.query("traindata_type == 'train'")) < 1:
+            errors_found.append(
+                "No labellocations with traindata_type == 'train' found! At least one "
+                "needed"
+            )
+        if len(labellocations_gdf.query("traindata_type == 'validation'")) < 1:
+            errors_found.append(
+                "No labellocations with traindata_type == 'validation' found! At least "
+                "one needed, but ~10% of the number of 'train' locations recommended."
+            )
+
         # Validate + process the polygons data
         # ------------------------------------
         if labelpolygons_gdf is None:
@@ -714,7 +725,6 @@ def _create_mask(
     minimum_pct_labeled: float = 0.0,
     force: bool = False,
 ) -> Optional[bool]:
-
     # If file exists already and force is False... stop.
     if force is False and output_mask_filepath.exists():
         logger.debug(


### PR DESCRIPTION
If there are no validation locations, this cryptic error is shown: `KeyError: 'val_one_hot_mean_iou'`.

This PR changes this to a clear error during prepare of the training data.