### PR TITLE
Refactor predict_dir to avoid locking issues

### DIFF
--- a/orthoseg/lib/predicter.py
+++ b/orthoseg/lib/predicter.py
@@ -117,8 +117,11 @@ def predict_dir(
     if output_vector_path is not None and output_vector_path.exists():
         logger.warning(f"output file exists already, so return: {output_vector_path}")
         return
-    tmp_dir = Path(tempfile.gettempdir()) / Path(__file__).stem
 
+    # Create tmp dir for this predict run
+    tmp_dir = Path(tempfile.gettempdir()) / "orthoseg"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    tmp_dir = Path(tempfile.mkdtemp(prefix=f"{Path(__file__).stem}_", dir=tmp_dir))
     logger.info(f"Start predict for input_image_dir: {input_image_dir}")
 
     # Eager and not eager prediction seems +- the same performance-wise
@@ -148,9 +151,10 @@ def predict_dir(
         image_filepaths.extend(input_image_dir.rglob("*" + input_ext_cur))
     image_filepaths = sorted(image_filepaths)
     nb_images = len(image_filepaths)
-    logger.info(
-        f"Found {nb_images} {input_ext} images to predict on in {input_image_dir}"
-    )
+
+    if nb_images == 0:
+        raise ValueError(f"Found no {input_ext} images to predict in {input_image_dir}")
+    logger.info(f"Found {nb_images} {input_ext} images to predict in {input_image_dir}")
 
     # If force is false, get list of all existing predictions
     # Getting the list once is way faster than checking file per file later on!
@@ -182,17 +186,18 @@ def predict_dir(
             pred_tmp_output_lock_path.unlink()
 
     # Loop through all files to process them
-    nb_parallel_read = batch_size * 6
+    nb_parallel_read = batch_size * 3
     if nb_parallel_postprocess == -1:
         nb_parallel_postprocess = multiprocessing.cpu_count()
-    predict_images = []
-    nb_to_process = nb_images
-    nb_processed = 0
+    predict_queue = []
+    nb_to_predict = nb_images
+    nb_done = 0
     nb_errors = 0
     read_sleep_logged = False
     progress = None
-    postp_future_to_input_path = {}
-    read_future_to_input_path = {}
+    read_queue = {}
+    postp_queue = {}
+    write_queue = {}
     image_id = -1
     last_image_reached = False
 
@@ -205,18 +210,19 @@ def predict_dir(
         nb_parallel_read
     ) as read_pool, futures.ProcessPoolExecutor(
         nb_parallel_postprocess, initializer=init_postprocess_worker()
-    ) as postprocess_pool:
-
+    ) as postprocess_pool, futures.ProcessPoolExecutor(
+        max_workers=1
+    ) as write_pool:
         # Start looping.
         # If ready to stop, the code below will break
         perf_time_start = datetime.datetime.now()
         while True:
-
             # If we are ready, stop!
             if (
                 last_image_reached is True
-                and len(read_future_to_input_path) == 0
-                and len(postp_future_to_input_path) == 0
+                and len(read_queue) == 0
+                and len(postp_queue) == 0
+                and len(write_queue) == 0
             ):
                 break
 
@@ -226,10 +232,18 @@ def predict_dir(
                 logger.info(f"Cancel file found, so stop: {cancel_filepath}")
                 break
 
-            # Get the next filepath to be processed
-            image_filepath = None
-            if image_id < (len(image_filepaths) - 1):
+            # Init for new loop
+            perfinfo = []
+
+            # Fill the read queue
+            # -------------------
+            while not last_image_reached and len(read_queue) <= nb_parallel_read:
                 image_id += 1
+
+                # Last image reached
+                if image_id >= len(image_filepaths) - 1:
+                    last_image_reached = True
+
                 image_filepath = image_filepaths[image_id]
 
                 # Check if the image has been processed already
@@ -238,43 +252,27 @@ def predict_dir(
                         "Predict for image has already been done before and force is "
                         f"False, so skip: {image_filepath.name}"
                     )
-                    nb_to_process -= 1
+                    nb_to_predict -= 1
                     continue
-
-                nb_processed += 1
 
                 # Schedule file to be read
                 read_future = read_pool.submit(
-                    read_image,  # Function
-                    image_filepath,  # Arg 1
-                    projection_if_missing,
-                )  # Arg 2)
-                read_future_to_input_path[read_future] = image_filepath
-            else:
-                last_image_reached = True
+                    read_image,
+                    image_filepath=image_filepath,
+                    projection_if_missing=projection_if_missing,
+                )
+                read_queue[read_future] = image_filepath
 
-            # Prepare batch_size images that have been read for prediction
-            while (
-                len(read_future_to_input_path) > 0 and len(predict_images) < batch_size
-            ):
-
-                # If the read pool is not full, first schedule extra reads
-                if (
-                    last_image_reached is False
-                    and len(read_future_to_input_path) < nb_parallel_read
-                ):
-                    break
-
+            # Check read_queue for images read and add them to predict_queue
+            # --------------------------------------------------------------
+            while len(read_queue) > 0 and len(predict_queue) < batch_size:
                 # Prepare the images that have been read for predicting
                 futures_done = [
-                    future
-                    for future in read_future_to_input_path
-                    if future.done() is True
+                    future for future in read_queue if future.done() is True
                 ]
                 for future in futures_done:
-
-                    # Prediction can only handle batch_size images
-                    if len(predict_images) >= batch_size:
+                    # predict_queue should contain maximum batch_size images!
+                    if len(predict_queue) >= batch_size:
                         break
 
                     try:
@@ -307,7 +305,7 @@ def predict_dir(
                                 / f"{image_filepath_read.stem}_pred{output_suffix}"
                             )
 
-                        predict_images.append(
+                        predict_queue.append(
                             {
                                 "input_image_filepath": image_filepath_read,
                                 "output_pred_filepath": output_image_pred_path,
@@ -320,24 +318,26 @@ def predict_dir(
 
                     finally:
                         # Remove from queue...
-                        del read_future_to_input_path[future]
+                        del read_queue[future]
 
-                # If not at last image + not enough images yet for predict + read
-                # queue is full, sleep
+                # If enough images in predict_queue or if the read queue is not full
+                # stop this loop
                 if (
-                    last_image_reached is False
-                    and len(predict_images) < batch_size
-                    and len(read_future_to_input_path) >= nb_parallel_read
+                    len(predict_queue) == batch_size
+                    or len(read_queue) < nb_parallel_read
                 ):
-                    if read_sleep_logged is False:
-                        logger.info("Wait for images to be read")
-                        read_sleep_logged = True
-                    time.sleep(0.01)
+                    break
 
-            # If batch_size images are ready for prediction or we are at
-            # the last images: predict
-            if len(predict_images) == batch_size or (
-                last_image_reached is True and len(predict_images) > 0
+                # Wait a bit for images to be read, then try finding images again
+                if not read_sleep_logged and not last_image_reached:
+                    logger.info("Wait for images to be read")
+                    read_sleep_logged = True
+                time.sleep(0.01)
+
+            # If sufficient images in predict queue -> predict
+            # ------------------------------------------------
+            if len(predict_queue) == batch_size or (
+                last_image_reached is True and len(predict_queue) > 0
             ):
                 read_sleep_logged = False
                 perf_time_now = datetime.datetime.now()
@@ -345,31 +345,30 @@ def predict_dir(
                 perf_time_start = perf_time_now
 
                 # Predict!
-                logger.debug(f"Start prediction for {len(predict_images)} images")
+                # --------
+                logger.debug(f"Start prediction for {len(predict_queue)} images")
                 perf_time_start = datetime.datetime.now()
                 curr_batch_image_list = [
-                    curr_batch_image_info["image_data"]
-                    for curr_batch_image_info in predict_images
+                    batch_image_info["image_data"] for batch_image_info in predict_queue
                 ]
-                curr_batch_image_arr = np.stack(curr_batch_image_list)
-                curr_batch_image_pred_arr = model.predict_on_batch(curr_batch_image_arr)
+                batch_image_arr = np.stack(curr_batch_image_list)
+                batch_pred_arr = model.predict_on_batch(batch_image_arr)
 
                 perf_time_now = datetime.datetime.now()
                 perfinfo += f", predict took {perf_time_now-perf_time_start}"
                 perf_time_start = perf_time_now
 
                 # In tf > 2.1 a tf.tensor object is returned, but we want an ndarray
-                if type(curr_batch_image_pred_arr) is tf.Tensor:
-                    curr_batch_image_pred_arr = np.array(
-                        curr_batch_image_pred_arr.numpy()  # type: ignore
-                    )
+                if isinstance(batch_pred_arr, tf.Tensor):
+                    arr = batch_pred_arr.numpy()  # pyright: ignore[reportOptionalCall]
+                    batch_pred_arr = np.array(arr)
                 else:
-                    curr_batch_image_pred_arr = np.array(curr_batch_image_pred_arr)
+                    batch_pred_arr = np.array(batch_pred_arr)
 
-                # Save predictions
-                # Remark: trying to parallelize this doesn't seem to help at all!
+                # Add predictions to postprocess queue
+                # ------------------------------------
                 logger.debug("Start post-processing")
-                for batch_image_id, image_info in enumerate(predict_images):
+                for batch_image_id, image_info in enumerate(predict_queue):
                     try:
                         # If not in evaluate mode... save to vector in background
                         if (
@@ -380,23 +379,24 @@ def predict_dir(
                             # Prepare prediction array...
                             #   - convert to uint8 to reduce pickle size/time
                             image_pred_arr_uint8 = (
-                                (curr_batch_image_pred_arr[batch_image_id, :, :, :])
-                                * 255
+                                (batch_pred_arr[batch_image_id, :, :, :]) * 255
                             ).astype(np.uint8)
+                            # Save to specific temp file to avoid locking issues.
+                            name = f"{image_info['input_image_filepath'].stem}.gpkg"
+                            prd_tmp_partial_output_file = tmp_dir / name
                             future = postprocess_pool.submit(
                                 postp.polygonize_pred_multiclass_to_file,
-                                image_pred_arr_uint8,
-                                image_info["image_crs"],
-                                image_info["image_transform"],
-                                classes,
-                                pred_tmp_output_path,
-                                min_probability,
-                                postprocess,
-                                border_pixels_to_ignore,
+                                image_pred_arr=image_pred_arr_uint8,
+                                image_crs=image_info["image_crs"],
+                                image_transform=image_info["image_transform"],
+                                classes=classes,
+                                output_vector_path=prd_tmp_partial_output_file,
+                                min_probability=min_probability,
+                                postprocess=postprocess,
+                                border_pixels_to_ignore=border_pixels_to_ignore,
+                                create_spatial_index=False,
                             )
-                            postp_future_to_input_path[future] = image_info[
-                                "input_image_filepath"
-                            ]
+                            postp_queue[future] = image_info["input_image_filepath"]
 
                         else:
                             # Saving the predictions as images at the moment only used
@@ -404,12 +404,10 @@ def predict_dir(
                             # TODO: would ideally be moved to the background
                             # processing as well to simplify code here...
                             postp.clean_and_save_prediction(
-                                image_image_filepath=image_info["input_image_filepath"],
+                                input_image_filepath=image_info["input_image_filepath"],
                                 image_crs=image_info["image_crs"],
                                 image_transform=image_info["image_transform"],
-                                image_pred_arr=curr_batch_image_pred_arr[
-                                    batch_image_id
-                                ],
+                                image_pred_arr=batch_pred_arr[batch_image_id],
                                 output_dir=image_info["output_image_pred_dir"],
                                 input_image_dir=input_image_dir,
                                 input_mask_dir=input_mask_dir,
@@ -432,107 +430,142 @@ def predict_dir(
                         image_path = image_info["input_image_filepath"]
                         _handle_error(image_path, ex, images_error_log_filepath)
 
+                # Reset variable for next batch
+                predict_queue = []
+
+                # Collect performance debugging info
                 perf_time_now = datetime.datetime.now()
                 perfinfo += (
                     f", scheduling postprocessings took {perf_time_now-perf_time_start}"
                 )
                 perf_time_start = perf_time_now
 
-                # Poll for completed postprocessings
-                postp_sleep_logged = False
-                while len(postp_future_to_input_path) > 0:
-
-                    # If not at last file, get results from all futures that are
-                    # done, if at last file, wait till all are done
-                    if last_image_reached is False:
-                        futures_done = [
-                            future
-                            for future in postp_future_to_input_path
-                            if future.done() is True
-                        ]
-                    else:
-                        logger.info("Wait for last batch")
-                        futures_done = futures.wait(postp_future_to_input_path).done
-                    for future in futures_done:
-                        # Get the result from the polygonization
-                        try:
-                            # Get the result (= exception when something went wrong)
-                            result = future.result()
-                            logger.debug(
-                                f"result for {postp_future_to_input_path[future].name}:"
-                                f" {result}"
-                            )
-
-                            # Write filepath to file with files that are done
-                            with images_done_log_filepath.open(
-                                "a+"
-                            ) as image_donelog_file:
-                                image_donelog_file.write(
-                                    postp_future_to_input_path[future].name + "\n"
-                                )
-                        except Exception as ex:
-                            nb_errors += 1
-                            image_path = postp_future_to_input_path[future]
-                            _handle_error(image_path, ex, images_error_log_filepath)
-
-                        finally:
-                            # Remove from queue...
-                            del postp_future_to_input_path[future]
-
-                    # Wait till number below thresshold to evade huge waiting
-                    # list (and memory issues)
-                    if len(postp_future_to_input_path) > nb_parallel_postprocess * 2:
-                        if postp_sleep_logged is False:
-                            logger.info(
-                                "Postprocessing takes longer than prediction, so wait"
-                            )
-                            postp_sleep_logged = True
-                        time.sleep(0.01)
-                    else:
-                        # No need to wait (anymore)...
-                        if postp_sleep_logged is True:
-                            logger.info(
-                                "Waited enough for postprocessing to catch up..."
-                            )
-
-                        perf_time_now = datetime.datetime.now()
-                        perfinfo += (
-                            f", after postproces: took {perf_time_now-perf_time_start}"
+            # Check postp_queue for completed postprocessings
+            # -----------------------------------------------
+            postp_sleep_logged = False
+            while len(postp_queue) > 0:
+                # If not at last file, get results from all futures that are
+                # done, if at last file, wait till all are done
+                futures_done = [
+                    future for future in postp_queue if future.done() is True
+                ]
+                for future in futures_done:
+                    # Get the result from the polygonization
+                    image_path = postp_queue[future]
+                    try:
+                        # Get the result (= exception when something went wrong)
+                        result = future.result()
+                        logger.debug(
+                            f"result for {postp_queue[future].name}:" f" {result}"
                         )
-                        perf_time_start = perf_time_now
-                        break
 
-                # Reset variable for next batch
-                predict_images = []
+                        name = f"{image_path.stem}.gpkg"
+                        partial_vector_path = tmp_dir / name
+                        write_future = write_pool.submit(
+                            _write_vector_result,
+                            image_path=image_path,
+                            partial_vector_path=partial_vector_path,
+                            vector_output_path=pred_tmp_output_path,
+                            images_done_log_filepath=images_done_log_filepath,
+                        )
+                        write_queue[write_future] = image_path
+                    except ImportError as ex:
+                        raise ex
+                    except Exception as ex:
+                        nb_errors += 1
+                        _handle_error(image_path, ex, images_error_log_filepath)
 
-                # Log the progress and prediction speed
-                if len(perfinfo) > 0:
-                    logger.debug(perfinfo)
-                if progress is not None:
-                    progress.step(nb_steps=batch_size)
-                # Init progress only when some imags were already processed, as the
-                # first are very slow.
-                if progress is None and nb_processed > 0:
-                    progress = ProgressLogger(
-                        message=f"predict to {output_image_dir.parent.name}/{output_image_dir.name}",  # noqa: E501
-                        nb_steps_total=nb_to_process,
-                        nb_steps_done=batch_size,
+                    finally:
+                        # Remove from queue...
+                        del postp_queue[future]
+
+                # Wait till number below thresshold to avoid huge waiting
+                # list (and memory issues)
+                if len(postp_queue) > nb_parallel_postprocess * 2:
+                    if postp_sleep_logged is False:
+                        logger.info(
+                            "Postprocessing takes longer than prediction, so wait"
+                        )
+                        postp_sleep_logged = True
+                    time.sleep(0.01)
+                else:
+                    # No need to wait (anymore)...
+                    if postp_sleep_logged is True:
+                        logger.info("Waited enough for postprocessing to catch up...")
+
+                    perf_time_now = datetime.datetime.now()
+                    perfinfo += (
+                        f", after postproces: took {perf_time_now-perf_time_start}"
                     )
-
-                # If max number errors reached, stop processings
-                if max_prediction_errors >= 0 and nb_errors >= max_prediction_errors:
+                    perf_time_start = perf_time_now
                     break
+
+            # Check write_queue for completed write operations
+            # ------------------------------------------------
+            write_sleep_logged = False
+            while len(write_queue) > 0:
+                # If not at last file, get results from all futures that are
+                # done, if at last file, wait till all are done
+                futures_done = [
+                    future for future in write_queue if future.done() is True
+                ]
+                for future in futures_done:
+                    # Get the result from the write
+                    try:
+                        # Get the result (= exception when something went wrong)
+                        result = future.result()
+                    except Exception as ex:
+                        nb_errors += 1
+                        image_path = write_queue[future]
+                        _handle_error(image_path, ex, images_error_log_filepath)
+
+                    finally:
+                        # Remove from queue...
+                        del write_queue[future]
+                        nb_done += 1
+
+                # Wait till number below thresshold to avoid huge waiting list (and
+                # memory issues)
+                if len(write_queue) > nb_parallel_postprocess * 2:
+                    if write_sleep_logged is False:
+                        logger.info("Writing takes longer than prediction, so wait")
+                        write_sleep_logged = True
+                    time.sleep(0.01)
+                else:
+                    # No need to wait (anymore)...
+                    if write_sleep_logged is True:
+                        logger.info("Waited enough for writing to catch up...")
+
+                    break
+
+            # Prepare for next loop
+            # ---------------------
+            # Log the progress and prediction speed
+            if len(perfinfo) > 0:
+                logger.debug(perfinfo)
+            if progress is not None:
+                progress.update(nb_steps_done=nb_done, nb_steps_total=nb_to_predict)
+            # Init progress only when some imags were already processed, as the
+            # first are very slow.
+            if progress is None and nb_done > 0:
+                progress = ProgressLogger(
+                    message=f"predict to {output_image_dir.parent.name}/{output_image_dir.name}",  # noqa: E501
+                    nb_steps_total=nb_to_predict,
+                    nb_steps_done=nb_done,
+                )
+
+            # If max number errors reached, stop processings
+            if max_prediction_errors >= 0 and nb_errors >= max_prediction_errors:
+                break
 
         # If errors occured, raise error
         if images_error_log_filepath.exists():
             errors = pd.read_csv(
-                images_error_log_filepath,
-                usecols=["filename", "error"]
-                # ).to_string(justify="left", index=False)
+                images_error_log_filepath, usecols=["filename", "error"]
             ).to_html(justify="left", index=False)
             raise Exception(f"Error(s) occured while predicting:\n{errors}")
 
-        # If alle images were processed, rename to real output file + cleanup
+        # If all images were processed, rename to real output file + cleanup
         if (
             last_image_reached is True
             and output_vector_path is not None
@@ -540,9 +573,33 @@ def predict_dir(
             and pred_tmp_output_path.exists()
         ):
             output_vector_path.parent.mkdir(parents=True, exist_ok=True)
+            gfo.create_spatial_index(pred_tmp_output_path, exist_ok=True)
             gfo.move(pred_tmp_output_path, output_vector_path)
             gfo.rename_layer(output_vector_path, output_vector_path.stem)
+            shutil.rmtree(tmp_dir, ignore_errors=True)
             shutil.rmtree(output_image_dir)
+
+
+def _write_vector_result(
+    image_path: Path,
+    partial_vector_path: Path,
+    vector_output_path: Path,
+    images_done_log_filepath: Path,
+):
+    # Copy the result to the main vector output file
+    if vector_output_path is not None:
+        if partial_vector_path.exists():
+            gfo.append_to(
+                src=partial_vector_path,
+                dst=vector_output_path,
+                dst_layer=vector_output_path.stem,
+                create_spatial_index=False,
+            )
+            gfo.remove(partial_vector_path)
+
+    # Write filepath to file with files that are done
+    with images_done_log_filepath.open("a+") as image_donelog_file:
+        image_donelog_file.write(image_path.name + "\n")
 
 
 def _handle_error(image_path: Path, ex: Exception, log_path: Path):
@@ -567,7 +624,6 @@ def _handle_error(image_path: Path, ex: Exception, log_path: Path):
 def read_image(
     image_filepath: Path, projection_if_missing: Optional[str] = None
 ) -> dict:
-
     # Read input file
     # Because sometimes a read seems to fail, retry up to 3 times...
     retry_count = 0

--- a/orthoseg/util/progress_util.py
+++ b/orthoseg/util/progress_util.py
@@ -35,8 +35,18 @@ class ProgressLogger:
         self.time_between_reporting_s = time_between_reporting_s
         self.calculate_eta_since_lastreporting = calculate_eta_since_lastreporting
 
-    def step(self, message: Optional[str] = None, nb_steps: int = 1):
+    def update(
+        self,
+        nb_steps_done: int,
+        nb_steps_total: int = None,
+        message: Optional[str] = None,
+    ):
+        if nb_steps_total is not None:
+            self.nb_steps_total = nb_steps_total
+        self.nb_steps_done = nb_steps_done
+        self.step(message=message, nb_steps=0)
 
+    def step(self, message: Optional[str] = None, nb_steps: int = 1):
         # Increase done counter
         self.nb_steps_done += nb_steps
 


### PR DESCRIPTION
Occassionaly "database locked" errors appear when predicting a directory.

This PR implements a refactor so writing to the output (.gpkg) file is done from one specific thread/process, so there are no concurrent writes and no locking issues.

Additionally the code is restructured to increase readability and performance.