### PR TITLE
ENH: change default nb concurrent calls when downloading a layer to 1 instead of 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Fix check that traindataset has validation samples should not be per file (#131)
 - Fix support for WMS username/password (#146)
 
+### Deprecations and compatibility notes
+
+- Change default nb_concurrent_calls when downloading layer to 1 instead of 6 (#)
+
 ## 0.5.0 (2023-07-27)
 
 ### Improvements

--- a/orthoseg/helpers/config_helper.py
+++ b/orthoseg/helpers/config_helper.py
@@ -237,7 +237,7 @@ def _read_layer_config(layer_config_filepath: Path) -> dict:
         # Read nb_concurrent calls param
         image_layers[image_layer]["nb_concurrent_calls"] = layer_config[
             image_layer
-        ].getint("nb_concurrent_calls", fallback=6)
+        ].getint("nb_concurrent_calls", fallback=1)
 
         # Check if a region of interest is specified as file or bbox
         image_layers[image_layer]["roi_filepath"] = layer_config[image_layer].getpath(

--- a/sample_projects/imagelayers.ini
+++ b/sample_projects/imagelayers.ini
@@ -26,7 +26,7 @@ grid_xmin=0
 grid_ymin=0
 
 # Options to manage the load that will be generated on the WMS server.
-# (Max) nb of parallel calls
+# (Max) nb of parallel calls (defaults to 1).
 nb_concurrent_calls = 2
 # Apply random nb of secs of sleep between 2 calls up to nb seconds specified. 
 #random_sleep = 10
@@ -57,7 +57,7 @@ grid_xmin=0
 grid_ymin=0
 
 # Options to manage the load that will be generated on the WMS server.
-# (Max) nb of parallel calls
+# (Max) nb of parallel calls (defaults to 1).
 nb_concurrent_calls = 2
 # Apply random nb of secs of sleep between 2 calls up to nb seconds specified. 
 #random_sleep = 10


### PR DESCRIPTION
It is not ideal that the default behaviour creates a lot of load on the WMS server, possibly leading to errors.