### PR TITLE
ENH: Add support to overrule configuration parameters via command line arguments - fix

### DIFF
--- a/orthoseg/load_images.py
+++ b/orthoseg/load_images.py
@@ -191,7 +191,8 @@ def load_images(
         )
         raise Exception(message) from ex
     finally:
-        shutil.rmtree(conf.tmp_dir, ignore_errors=True)
+        if conf.tmp_dir is not None:
+            shutil.rmtree(conf.tmp_dir, ignore_errors=True)
 
 
 def main():

--- a/orthoseg/postprocess.py
+++ b/orthoseg/postprocess.py
@@ -160,7 +160,8 @@ def postprocess(config_path: Path, config_overrules: List[str] = []):
         )
         raise Exception(message) from ex
     finally:
-        shutil.rmtree(conf.tmp_dir, ignore_errors=True)
+        if conf.tmp_dir is not None:
+            shutil.rmtree(conf.tmp_dir, ignore_errors=True)
 
 
 def main():

--- a/orthoseg/predict.py
+++ b/orthoseg/predict.py
@@ -315,7 +315,8 @@ def predict(config_path: Path, config_overrules: List[str] = []):
         )
         raise Exception(message) from ex
     finally:
-        shutil.rmtree(conf.tmp_dir, ignore_errors=True)
+        if conf.tmp_dir is not None:
+            shutil.rmtree(conf.tmp_dir, ignore_errors=True)
 
 
 def main():

--- a/orthoseg/train.py
+++ b/orthoseg/train.py
@@ -465,7 +465,8 @@ def train(config_path: Path, config_overrules: List[str] = []):
         email_helper.sendmail(subject=message, body=message_body)
         raise Exception(message) from ex
     finally:
-        shutil.rmtree(conf.tmp_dir, ignore_errors=True)
+        if conf.tmp_dir is not None:
+            shutil.rmtree(conf.tmp_dir, ignore_errors=True)
 
 
 def main():


### PR DESCRIPTION
Avoid error during shutdown and cleanup op orthoseg if tmp_dir doesn't exist.

reference #152 