### PR TITLE
ENH: don't treat larger than expected training location rectangle as error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Improvements
 
-- Add support to train subject on different pixel sizes (#143)
+- Add support to train subject on different pixel sizes (#143, #174)
 - Add support to overrule configuration parameters via command line arguments (#152)
 - Several small improvements (#128)
 

--- a/orthoseg/helpers/config_helper.py
+++ b/orthoseg/helpers/config_helper.py
@@ -348,7 +348,7 @@ def _prepare_train_label_infos(
             )
         }
 
-    # If there are label datasources configures in the project, process them as well.
+    # If there are label datasources configured in the project, process them as well.
     if label_datasources is not None:
         for label_ds_key in label_datasources:
             label_ds = label_datasources[label_ds_key]
@@ -357,7 +357,7 @@ def _prepare_train_label_infos(
             polygons_path = None
             if "polygons_path" in label_ds:
                 polygons_path = label_ds["polygons_path"]
-            if "data_path" in label_ds:
+            elif "data_path" in label_ds:
                 polygons_path = label_ds["data_path"]
 
             # If the label datasource was already found using pattern search, overrule
@@ -373,6 +373,9 @@ def _prepare_train_label_infos(
                 if label_ds.get("pixel_y_size") is not None:
                     label_infos[locations_path].pixel_y_size = label_ds["pixel_y_size"]
             else:
+                if polygons_path is None:
+                    raise ValueError(f"polygons_path not specified for {label_ds}")
+
                 # Add as new LabelInfo
                 label_infos[locations_path] = LabelInfo(
                     locations_path=Path(label_ds["locations_path"]),


### PR DESCRIPTION
The training location rectangle being too large is typically not a problem because the only importance is to show the size of the area that should be properly annotated.

If it is too large:
- too much area might me annotated by the user, which is no problem for the training
- due to the location being used is smaller than (possibly) expected by the user, that the included (part of) the subject becomes too small or context that was expected to be present might not be there, which could be negatively impact the training process.

Even there are some situations where it is a downside, better just to let it pass anyway because otherwise it is not possible to use the same training data to train on multiple resolutions.