### PR TITLE
BUG: in load_images, occassionaly an error occurs when deleting redundant files,...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fix check that traindataset has validation samples should not be per file (#131)
 - Fix support for WMS username/password (#146)
 - Fix train gives an error after training if there are no "test" locations defined (#165)
+- Fix occassional errors when deleting redundant files in `load_images` (#186)
 
 ### Deprecations and compatibility notes
 

--- a/orthoseg/util/ows_util.py
+++ b/orthoseg/util/ows_util.py
@@ -27,6 +27,7 @@ from rasterio import (
     transform as rio_transform,
     windows as rio_windows,
 )
+from rasterio._err import CPLE_AppDefinedError
 
 from . import progress_util
 
@@ -840,13 +841,27 @@ def getmap_to_file(
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=rio_errors.NotGeoreferencedWarning)
 
-        with rio.open(str(output_filepath), "w", **image_profile_output) as image_file:
-            image_file.write(image_data_output)
+        try:
+            with rio.open(
+                str(output_filepath), "w", **image_profile_output
+            ) as image_file:
+                image_file.write(image_data_output)
+        except CPLE_AppDefinedError as ex:
+            if ex.errmsg.startswith("Deleting ") and ex.errmsg.endswith(
+                " failed: No such file or directory"
+            ):
+                # Occasionally this error occurs, not sure why: ignore it.
+                logger.debug(f"Ignore error: {ex}")
+            else:
+                raise ex
 
     # If an aux.xml file was written, remove it again...
     output_aux_path = output_filepath.parent / f"{output_filepath.name}.aux.xml"
-    if output_aux_path.exists() is True:
-        output_aux_path.unlink()
+    try:
+        output_aux_path.unlink(missing_ok=True)
+    except Exception as ex:
+        # Occasionally the .aux.xml file is locked, not sure why: ignore it.
+        logger.debug(f"Ignore error: {ex}")
 
     # Make the output image compliant with image_format_save
 

--- a/orthoseg/util/ows_util.py
+++ b/orthoseg/util/ows_util.py
@@ -846,7 +846,7 @@ def getmap_to_file(
                 str(output_filepath), "w", **image_profile_output
             ) as image_file:
                 image_file.write(image_data_output)
-        except CPLE_AppDefinedError as ex:
+        except CPLE_AppDefinedError as ex:  # pragma: no cover
             if ex.errmsg.startswith("Deleting ") and ex.errmsg.endswith(
                 " failed: No such file or directory"
             ):
@@ -859,7 +859,7 @@ def getmap_to_file(
     output_aux_path = output_filepath.parent / f"{output_filepath.name}.aux.xml"
     try:
         output_aux_path.unlink(missing_ok=True)
-    except Exception as ex:
+    except Exception as ex:  # pragma: no cover
         # Occasionally the .aux.xml file is locked, not sure why: ignore it.
         logger.debug(f"Ignore error: {ex}")
 


### PR DESCRIPTION
When deleting some unneeded .aux.xml files, this sometimes fails due to them not existing or being locked.

Not sure why it occur, but this PR just catches and ignores these errors as they are functionally unimportant.