### PR TITLE
BUG: error when validating some empty traindata files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.6.1 (????-??-??)
+
+### Bugs fixed
+
+- Fix error when validating some empty traindata files (#192)
+
 ## 0.6.0 (2024-07-26)
 
 ### Deprecations and compatibility notes

--- a/orthoseg/lib/prepare_traindatasets.py
+++ b/orthoseg/lib/prepare_traindatasets.py
@@ -587,15 +587,16 @@ def prepare_labeldata(
             continue
 
         # Create list with only the input polygons that need to be burned in the mask
-        labels_to_burn_gdf = None
+        labels_to_burn_gdf = labelpolygons_gdf.copy()
+        labels_to_burn_gdf["burn_value"] = None
+
         if labelname_column not in labelpolygons_gdf.columns:
             # For backwards compatibility, also support old default column name
             labelname_column = "label_name"
+
         if labelname_column in labelpolygons_gdf.columns:
             # If there is a column labelname_column, use the burn values specified in
             # the configuration
-            labels_to_burn_gdf = labelpolygons_gdf
-            labels_to_burn_gdf.loc[:, "burn_value"] = None
             for classname in classes:
                 labels_to_burn_gdf.loc[
                     (
@@ -628,7 +629,6 @@ def prepare_labeldata(
                 f"Column ({labelname_column}) not found, so use all polygons in "
                 f"{label_info.polygons_path.name}"
             )
-            labels_to_burn_gdf = labelpolygons_gdf
             labels_to_burn_gdf.loc[:, "burn_value"] = 1
 
         else:
@@ -637,13 +637,6 @@ def prepare_labeldata(
                 f"Column {labelname_column} is mandatory in labeldata if multiple "
                 f"classes specified: {classes}"
             )
-
-        # Check if we ended up with label data to burn.
-        if labels_to_burn_gdf is None:
-            validation_errors.append(
-                "Not any labelpolygon retained to burn in the training data!"
-            )
-            continue
 
         # Filter away None and empty geometries... they cannot be burned
         with warnings.catch_warnings():


### PR DESCRIPTION
Exception when validating an empty polygon traindata file without explicit classname column.

Exception thrown: `Exception: cannot set a frame with no defined index and a scalar`