### PR TITLE
BUG: fix error in `prepare_traindatasets` when a polygons training dataset is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Bugs fixed
 
-- Fix error when validating some empty traindata files (#192)
+- Fix error in `prepare_traindatasets` when a polygons training dataset is empty
+  (#192, #193)
 
 ## 0.6.0 (2024-07-26)
 

--- a/orthoseg/lib/prepare_traindatasets.py
+++ b/orthoseg/lib/prepare_traindatasets.py
@@ -379,6 +379,8 @@ def prepare_traindatasets(
                     nb_classes = len(classes)
 
                     # Only keep the labels that are meant for this image layer
+                    if "image_layer" not in labels_to_burn_gdf.columns:
+                        print("odd")
                     labels_for_layer_gdf = (
                         labels_to_burn_gdf.loc[
                             labels_to_burn_gdf["image_layer"] == image_layer
@@ -450,12 +452,11 @@ def prepare_labeldata(
         else:
             logger.debug(f"Read label locations from {label_info.locations_path}")
             labellocations_gdf = gfo.read_file(label_info.locations_path)
-            if labellocations_gdf is not None and len(labellocations_gdf) > 0:
-                labellocations_gdf.loc[:, "path"] = str(label_info.locations_path)
-                labellocations_gdf.loc[:, "image_layer"] = label_info.image_layer
-                # Remark: geopandas 0.7.0 drops fid column internally!
-                labellocations_gdf.loc[:, "row_nb_orig"] = labellocations_gdf.index
-            else:
+            labellocations_gdf["path"] = str(label_info.locations_path)
+            labellocations_gdf["image_layer"] = label_info.image_layer
+            # Remark: geopandas 0.7.0 drops fid column internally!
+            labellocations_gdf["row_nb_orig"] = labellocations_gdf.index
+            if len(labellocations_gdf) == 0:
                 logger.warning(
                     f"No label locations found in {label_info.locations_path}"
                 )
@@ -467,10 +468,9 @@ def prepare_labeldata(
         else:
             logger.debug(f"Read label data from {label_info.polygons_path}")
             labelpolygons_gdf = gfo.read_file(label_info.polygons_path)
-            if labelpolygons_gdf is not None and len(labelpolygons_gdf) > 0:
-                labelpolygons_gdf.loc[:, "path"] = str(label_info.polygons_path)
-                labelpolygons_gdf.loc[:, "image_layer"] = label_info.image_layer
-            else:
+            labelpolygons_gdf["path"] = str(label_info.polygons_path)
+            labelpolygons_gdf["image_layer"] = label_info.image_layer
+            if len(labelpolygons_gdf) == 0:
                 logger.warning(f"No label polygons found in {label_info.polygons_path}")
 
         assert labellocations_gdf is not None


### PR DESCRIPTION
Exception thrown:

``` py
Exception: 'image_layer'

Traceback (most recent call last): File "C:\Tools\mambaforge\envs\orthoseg\lib\site-packages\pandas\core\indexes\base.py", line 3805, in get_loc return self._engine.get_loc(casted_key) File "index.pyx", line 167, in pandas._libs.index.IndexEngine.get_loc File "index.pyx", line 196, in pandas._libs.index.IndexEngine.get_loc File "pandas\\_libs\\hashtable_class_helper.pxi", line 7081, in pandas._libs.hashtable.PyObjectHashTable.get_item File "pandas\\_libs\\hashtable_class_helper.pxi", line 7089, in pandas._libs.hashtable.PyObjectHashTable.get_item KeyError: 'image_layer' The above exception was the direct cause of the following exception: Traceback (most recent call last): File "C:\Tools\mambaforge\envs\orthoseg\lib\site-packages\orthoseg\train.py", line 107, in train training_dir, traindata_id = prep.prepare_traindatasets( File "C:\Tools\mambaforge\envs\orthoseg\lib\site-packages\orthoseg\lib\prepare_traindatasets.py", line 401, in prepare_traindatasets raise ex File "C:\Tools\mambaforge\envs\orthoseg\lib\site-packages\orthoseg\lib\prepare_traindatasets.py", line 384, in prepare_traindatasets labels_to_burn_gdf["image_layer"] == image_layer File "C:\Tools\mambaforge\envs\orthoseg\lib\site-packages\geopandas\geodataframe.py", line 1750, in __getitem__ result = super().__getitem__(key) File "C:\Tools\mambaforge\envs\orthoseg\lib\site-packages\pandas\core\frame.py", line 4102, in __getitem__ indexer = self.columns.get_loc(key) File "C:\Tools\mambaforge\envs\orthoseg\lib\site-packages\pandas\core\indexes\base.py", line 3812, in get_loc raise KeyError(key) from err KeyError: 'image_layer' 

```