### PR TITLE
Write all tmp files to "orthoseg" subdir in `gettempdir`

### DIFF
--- a/orthoseg/lib/predicter.py
+++ b/orthoseg/lib/predicter.py
@@ -112,7 +112,7 @@ def predict_dir(
         return
 
     # Create tmp dir for this predict run
-    tmp_dir = Path(tempfile.gettempdir()) / "orthoseg"
+    tmp_dir = Path(tempfile.gettempdir())
     tmp_dir.mkdir(parents=True, exist_ok=True)
     tmp_dir = Path(tempfile.mkdtemp(prefix=f"{Path(__file__).stem}_", dir=tmp_dir))
     logger.info(f"Start predict for input_image_dir: {input_image_dir}")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,6 @@
 import re
+import tempfile
+from pathlib import Path
 
 import pytest
 
@@ -197,3 +199,10 @@ def test_unformat_error():
             "fields_BEFL-2018_polygons.gpkg",
             pattern="fields_{image_layer}_data.gpkg",
         )
+
+
+def test_tmpdir():
+    tmpdir = conf._set_tmp_dir("orthoseg")
+
+    assert tmpdir.exists()
+    assert tmpdir == Path(tempfile.gettempdir())


### PR DESCRIPTION
Write all tmp files to "orthoseg" subdir in `gettempdir`, so they are easier to find/cleanup if needed.