### PR TITLE
TST: skip test_prepare_traindatasets on windows as it crashes

### DIFF
--- a/tests/test_prepare_traindata.py
+++ b/tests/test_prepare_traindata.py
@@ -301,7 +301,7 @@ image_2 = "150200_150200_150328_150328_512_512_OMWRGB19VL.png"
 image_3 = "150300_150300_150428_150428_512_512_OMWRGB19VL.png"
 
 
-# @pytest.mark.skipif(os.name == "nt", reason="crashes on windows")
+@pytest.mark.skipif(os.name == "nt", reason="crashes on windows")
 @pytest.mark.parametrize(
     "copy_images, match, mismatch, error, filesize_kb",
     [


### PR DESCRIPTION
Gives "Segmentation fault"... put quite some time in it trying to find out why, but not found :-(...

When running opperationally never had the issue, so it is something quite specific being triggered by the test.