### PR TITLE
CI: use pre-commit.ci instead of github action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,18 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  Linting:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - uses: pre-commit/action@v3.0.1
-
   Test:
-    needs: Linting
     name: ${{ matrix.env }} - python ${{ matrix.python }} - ${{ matrix.os }}
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+ci:
+    autofix_prs: false
+    autoupdate_schedule: quarterly
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.7.4"


### PR DESCRIPTION
Using the action is in maintenance only mode, and the advice is to use pre-commit-ci instead: https://github.com/pre-commit/action