### PR TITLE
ENH: include traindata id in status mails sent + clarify errors when thrown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Improve performance of `predict_dir` for `evaluation_mode` (#236)
 - Make `load_images` more robust by ignoring some filesystem errors that occur sometimes
   but that don't seem to give actual issues (#216, #2019)
-- Small improvements to logging, error messages,... (#198, #218)
+- Small improvements to logging, error messages,... (#198, #218, #247)
 - Add support + tests for latest tensorflow version (#217)
 - Update minimal dependencies: drop support of python 3.9, geopandas 1.x,...
   (#229, #230)

--- a/orthoseg/load_images.py
+++ b/orthoseg/load_images.py
@@ -177,7 +177,7 @@ def load_images(
         email_helper.sendmail(
             subject=message, body=f"Exception: {ex}\n\n {traceback.format_exc()}"
         )
-        raise RuntimeError(message) from ex
+        raise RuntimeError(f"{message}: {ex}") from ex
     finally:
         conf.remove_run_tmp_dir()
 

--- a/orthoseg/model/model_helper.py
+++ b/orthoseg/model/model_helper.py
@@ -519,7 +519,8 @@ def get_best_model(
         trainparams_id (int, optional): only models with this hyperparams id
 
     Returns:
-        A dictionary with the info of the best model, or None if no model was found
+        A dictionary with the info of the best model as returned by
+        parse_model_filename, or None if no model was found
     """
     # Get list of existing models for this train dataset
     model_info_list = get_models(

--- a/orthoseg/predict.py
+++ b/orthoseg/predict.py
@@ -351,7 +351,7 @@ def predict(config_path: Path, config_overrules: list[str] = []):
         email_helper.sendmail(
             subject=message, body=f"Exception: {ex}\n\n {traceback.format_exc()}"
         )
-        raise RuntimeError(message) from ex
+        raise RuntimeError(f"{message}: {ex}") from ex
     finally:
         conf.remove_run_tmp_dir()
 

--- a/orthoseg/predict.py
+++ b/orthoseg/predict.py
@@ -77,6 +77,7 @@ def predict(config_path: Path, config_overrules: list[str] = []):
     logger = log_util.main_log_init(conf.dirs.getpath("log_dir"), __name__)
     logger.info(f"Start predict for config {config_path.stem}")
     logger.debug(f"Config used: \n{conf.pformat_config()}")
+    detection_name = None
 
     try:
         # Read some config, and check if values are ok
@@ -111,10 +112,12 @@ def predict(config_path: Path, config_overrules: list[str] = []):
                 f"traindata_id: {traindata_id}"
             )
             logger.critical(message)
-            raise Exception(message)
+            raise RuntimeError(message)
         else:
             model_weights_filepath = best_model["filepath"]
             logger.info(f"Best model found: {model_weights_filepath}")
+
+        detection_name = f"{best_model['segment_subject']}_{best_model['traindata_id']}"
 
         # Load the hyperparams of the model
         # TODO: move the hyperparams filename formatting to get_models...
@@ -261,7 +264,7 @@ def predict(config_path: Path, config_overrules: list[str] = []):
         # Start predict for entire dataset
         # --------------------------------
         # Send email
-        email_helper.sendmail(f"Start predict for {config_path.stem} on {image_layer}")
+        email_helper.sendmail(f"Start prediction {detection_name} on {image_layer}")
 
         # Check if we should use an image cache
         use_cache = image_layer_config.get("use_cache", "yes")
@@ -320,7 +323,7 @@ def predict(config_path: Path, config_overrules: list[str] = []):
             )
 
         # Log and send mail
-        message = f"Completed predict for {config_path.stem} on {image_layer}"
+        message = f"Completed prediction {detection_name} on {image_layer}"
         logger.info(message)
         email_helper.sendmail(message)
 
@@ -341,7 +344,9 @@ def predict(config_path: Path, config_overrules: list[str] = []):
             simulate=conf.cleanup.getboolean("simulate"),
         )
     except Exception as ex:
-        message = f"ERROR in predict for {config_path.stem} on {image_layer}"
+        if detection_name is None:
+            detection_name = config_path.stem
+        message = f"ERROR in prediction {detection_name}, on {image_layer}"
         logger.exception(message)
         email_helper.sendmail(
             subject=message, body=f"Exception: {ex}\n\n {traceback.format_exc()}"

--- a/orthoseg/predict.py
+++ b/orthoseg/predict.py
@@ -77,7 +77,7 @@ def predict(config_path: Path, config_overrules: list[str] = []):
     logger = log_util.main_log_init(conf.dirs.getpath("log_dir"), __name__)
     logger.info(f"Start predict for config {config_path.stem}")
     logger.debug(f"Config used: \n{conf.pformat_config()}")
-    detection_name = None
+    model_name = None
 
     try:
         # Read some config, and check if values are ok
@@ -117,7 +117,7 @@ def predict(config_path: Path, config_overrules: list[str] = []):
             model_weights_filepath = best_model["filepath"]
             logger.info(f"Best model found: {model_weights_filepath}")
 
-        detection_name = f"{best_model['segment_subject']}_{best_model['traindata_id']}"
+        model_name = f"{best_model['segment_subject']}_{best_model['traindata_id']}"
 
         # Load the hyperparams of the model
         # TODO: move the hyperparams filename formatting to get_models...
@@ -264,7 +264,7 @@ def predict(config_path: Path, config_overrules: list[str] = []):
         # Start predict for entire dataset
         # --------------------------------
         # Send email
-        email_helper.sendmail(f"Start prediction {detection_name} on {image_layer}")
+        email_helper.sendmail(f"Start predict for {model_name} on {image_layer}")
 
         # Check if we should use an image cache
         use_cache = image_layer_config.get("use_cache", "yes")
@@ -323,7 +323,7 @@ def predict(config_path: Path, config_overrules: list[str] = []):
             )
 
         # Log and send mail
-        message = f"Completed prediction {detection_name} on {image_layer}"
+        message = f"Completed predict for {model_name} on {image_layer}"
         logger.info(message)
         email_helper.sendmail(message)
 
@@ -344,9 +344,9 @@ def predict(config_path: Path, config_overrules: list[str] = []):
             simulate=conf.cleanup.getboolean("simulate"),
         )
     except Exception as ex:
-        if detection_name is None:
-            detection_name = config_path.stem
-        message = f"ERROR in prediction {detection_name}, on {image_layer}"
+        if model_name is None:
+            model_name = config_path.stem
+        message = f"ERROR in predict for {model_name} on {image_layer}"
         logger.exception(message)
         email_helper.sendmail(
             subject=message, body=f"Exception: {ex}\n\n {traceback.format_exc()}"

--- a/orthoseg/train.py
+++ b/orthoseg/train.py
@@ -117,7 +117,7 @@ def train(config_path: Path, config_overrules: list[str] = []):
             )
 
         # Send mail that we are starting train
-        email_helper.sendmail(f"Start train for {config_path.stem}")
+        email_helper.sendmail(f"Start train for {config_path.stem} ({traindata_id=})")
         logger.info(
             f"Traindata dir to use is {training_dir}, with traindata_id: {traindata_id}"
         )
@@ -414,7 +414,7 @@ def train(config_path: Path, config_overrules: list[str] = []):
         gc.collect()
 
         # Log and send mail
-        message = f"Completed train for {config_path.stem}"
+        message = f"Completed train for {config_path.stem} ({traindata_id=})"
         logger.info(message)
         email_helper.sendmail(message)
     except Exception as ex:

--- a/orthoseg/train.py
+++ b/orthoseg/train.py
@@ -425,7 +425,7 @@ def train(config_path: Path, config_overrules: list[str] = []):
         else:
             message_body = f"Exception: {ex}<br/><br/>{traceback.format_exc()}"
         email_helper.sendmail(subject=message, body=message_body)
-        raise RuntimeError(message) from ex
+        raise RuntimeError(f"{message}: {ex}") from ex
     finally:
         conf.remove_run_tmp_dir()
 


### PR DESCRIPTION
Added traindata_id in status mails sent for train, predict and postprocess.