### PR TITLE
MAINT: fix geofileops deprecation -> min geofileops version: 0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.7.0 (????-??-??)
 
+### Deprecations and compatibility notes
+
+- Add support + tests for recent tensorflow versions (2.19 at time of writing) (#217)
+- Update minimal dependencies. Most notable ones: drop support of python 3.9,
+  geopandas >=1.0, geofileops >= 0.10. (#229, #230, #271)
+
 ### Improvements
 
 - Support reading images directly from the datasource while predicting (#228, #231)
@@ -17,9 +23,6 @@
 - Make `load_images` more robust by ignoring some filesystem errors that occur sometimes
   but that don't seem to give actual issues (#216, #2019)
 - Small improvements to logging, error messages,... (#198, #218, #247)
-- Add support + tests for latest tensorflow version (#217)
-- Update minimal dependencies: drop support of python 3.9, geopandas 1.x,...
-  (#229, #230)
 
 ### Bugs fixed
 
@@ -41,6 +44,7 @@
 ### Deprecations and compatibility notes
 
 - Change default nb_concurrent_calls when downloading layer to 1 instead of 6 (##149)
+- Update dependencies: geopandas, ruff,... + drop support for pygeos (#179)
 
 ### Improvements
 
@@ -53,7 +57,6 @@
 - In prepare_trainingdata, reuse images already available in previous version (#170)
 - Several small improvements to logging, documentation,... (#128, #180, #185)
 - Apply pyupgrade (python >= 3.9), pydocstyle, isort and mypy (#181, #182, #184, #187)
-- Update dependencies: geopandas, ruff,... + drop support for pygeos (#179)
 
 ### Bugs fixed
 
@@ -64,11 +67,14 @@
 
 ## 0.5.0 (2023-07-27)
 
+### Deprecations and compatibility notes
+
+- Support geopandas 0.13 + remove dependency on pygeos (#121)
+
 ### Improvements
 
 - Add support to train and detect on local image file layer (#111)
 - Add check that train and validation data is mandatory (#118)
-- Support geopandas 0.13 + remove dependency on pygeos (#121)
 - Improve performance of prepare_traindatasets for large label files (#116)
 - Use [pygeoops](https://github.com/pygeoops/pygeoops) for inline simplification during
   predict (#123):
@@ -93,6 +99,11 @@
 
 ## 0.4.1 (2023-01-20)
 
+### Deprecations and compatibility notes
+
+- Remove old model architectures: standard+unet and ternaus+unet (#82)
+- Add support for shapely 2 (#92)
+
 ### Improvements
 
 - Avoid warning blockysize is not supported for jpeg when downloading images (#77)
@@ -100,7 +111,6 @@
 - Add option to specify reclassify to neighbour query as postprocessing (#86, #88)
 - Reuse sample_project for tests so it is tested as well (#81)
 - Improve test coverage (#79, #82, #83)
-- Add support for shapely 2 (#92)
 
 ### Bugs fixed
 
@@ -110,11 +120,13 @@
 - Fix error when prediction output dir doesn't exist yet (#75)
 - Fix reclassify_to_neighbours giving undetermined result when 2+ neighbours are reclassification candidates (#84)
 
+## 0.4.0 (2022-11-14)
+
 ### Deprecations and compatibility notes
 
-- Remove old model architectures: standard+unet and ternaus+unet (#82)
-
-## 0.4.0 (2022-11-14)
+- Support newer versions of used packages (#59, #61, #62)
+- Disable default simplify in postprocess (#32)
+- Command 'scriptrunner' renamed to 'osscriptrunner' (#59)
 
 ### Improvements
 
@@ -134,16 +146,14 @@
 - Add option to disable ssl verification when downloading sample projects (#64)
 - Apply black formatting to comply with pep8 (#27)
 - Enable running CI tests using github actions (#42, #67)
-- Support newer versions of used packages (#59, #61, #62)
-
-### Deprecations and compatibility notes
-
-- Disable default simplify in postprocess (#32)
-- Command 'scriptrunner' renamed to 'osscriptrunner' (#59)
 
 ## 0.3.0 (2022-02-10)
 
 Highlights for this release are a feature to be able to combine bands from different WMS layers to one (3 band) input layer, performance improvements,...
+
+### Deprecations and compatibility notes
+
+- Update dependencies, eg. tensorflow 2.8, geofileops 0.3, geopandas 0.10,...
 
 ### Improvements
 
@@ -155,7 +165,6 @@ Highlights for this release are a feature to be able to combine bands from diffe
 - Improve/update documentation + sample project
 - Improve prediction performance (#5)
 - Improve logging
-- Update dependencies, eg. tensorflow 2.8, geofileops 0.3, geopandas 0.10,...
 
 ### Bugs fixed
 
@@ -169,6 +178,10 @@ For typical segmentation projects the changes should be backwards compatible. If
 
 train.image_augmentations, train.mask_augmentations
 train.classes
+
+### Deprecations and compatibility notes
+
+- Update tensorflow dependency to 2.4
 
 ### Improvements
 
@@ -186,7 +199,6 @@ train.classes
   the train.save_augmented_subdir parameter in project_defaults.ini
 - Cleanup support for uninteresting models
 - Improve logging, progress reporting, type annotations
-- Update tensorflow dependency to 2.4
 
 ### Bugs fixed
 

--- a/ci/envs/environment-tf-pip.yml
+++ b/ci/envs/environment-tf-pip.yml
@@ -13,7 +13,7 @@ dependencies:
   # required
   - gdal # <3.11  # gdal 3.11 triggers issues with tensorflow
   - gdown
-  - geofileops >=0.9
+  - geofileops >=0.10
   - geopandas-base >=1.0
   - matplotlib-base
   - numpy <2.2  # Tensorflow 2.19 needs a limit on the numpy version

--- a/ci/envs/environment-win-gpu.yml
+++ b/ci/envs/environment-win-gpu.yml
@@ -16,8 +16,8 @@ dependencies:
   - cudnn <9  # tf 2.10 requires cudnn 8
   - gdal
   - gdown
-  - geofileops >=0.9,<0.11
-  - geopandas-base >=1.0,<1.2
+  - geofileops >=0.10
+  - geopandas-base >=1.0
   - matplotlib-base
   - numpy <2  # <2 is needed for tf < 2.18
   - owslib

--- a/ci/envs/environment.yml
+++ b/ci/envs/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   # required
   - gdal
   - gdown
-  - geofileops >=0.9
+  - geofileops >=0.10
   - geopandas-base >=1.0
   - matplotlib-base
   - numpy

--- a/ci/envs/latest-tf-pip.yml
+++ b/ci/envs/latest-tf-pip.yml
@@ -13,7 +13,7 @@ dependencies:
   # required
   - gdal # <3.11  # gdal 3.11 triggers issues with tensorflow
   - gdown
-  - geofileops >=0.9
+  - geofileops >=0.10
   - geopandas-base >=1.0
   - matplotlib-base
   - numpy <2.2  # Tensorflow 2.19 needs a limit on the numpy version

--- a/ci/envs/latest.yml
+++ b/ci/envs/latest.yml
@@ -8,7 +8,7 @@ dependencies:
   # required
   - gdal
   - gdown
-  - geofileops >=0.9
+  - geofileops >=0.10
   - geopandas-base >=1.0
   - matplotlib-base
   - numpy

--- a/ci/envs/minimal.yml
+++ b/ci/envs/minimal.yml
@@ -26,7 +26,7 @@ dependencies:
   - rasterio
   - shapely =2.0  # released 2022-12-12
   - simplification
-  - vs2015_runtime <14.44.35208  # Try to avoid segmentation faults
+  - vs2015_runtime <14.42  # Try to avoid segmentation faults
   # dependencies of tensorflow that need to be conda versions to avoid binary compatibility issues
   - h5py =3.9  # When a version > 3.10 is used with tf 2.10: segmentation fault
   # testing

--- a/ci/envs/minimal.yml
+++ b/ci/envs/minimal.yml
@@ -14,17 +14,17 @@ dependencies:
   # required
   - gdal =3.7  # 3.7.0 released 2023-05-03
   - gdown
-  - geofileops =0.10
-  - geopandas-base =1.0
+  - geofileops =0.10  # 0.10.0 released 2025-03-26
+  - geopandas-base =1.0  # 1.0.0 released 2024-06-24
   - matplotlib-base
   - numpy =1.26  # <2 is needed for tf < 2.18
   - owslib
   - pillow
   - pycron
-  - pygeoops =0.4
+  - pygeoops =0.4  # released 2023-11-24
   - pyproj
   - rasterio
-  - shapely =2.0
+  - shapely =2.0  # released 2022-12-12
   - simplification
   # dependencies of tensorflow that need to be conda versions to avoid binary compatibility issues
   - h5py =3.9  # When a version > 3.10 is used with tf 2.10: segmentation fault

--- a/ci/envs/minimal.yml
+++ b/ci/envs/minimal.yml
@@ -26,6 +26,7 @@ dependencies:
   - rasterio
   - shapely =2.0  # released 2022-12-12
   - simplification
+  - vs2015_runtime <14.44.35208  # Try to avoid segmentation faults
   # dependencies of tensorflow that need to be conda versions to avoid binary compatibility issues
   - h5py =3.9  # When a version > 3.10 is used with tf 2.10: segmentation fault
   # testing

--- a/ci/envs/minimal.yml
+++ b/ci/envs/minimal.yml
@@ -26,7 +26,6 @@ dependencies:
   - rasterio
   - shapely =2.0  # released 2022-12-12
   - simplification
-  - vs2015_runtime <14.42  # Try to avoid segmentation faults
   # dependencies of tensorflow that need to be conda versions to avoid binary compatibility issues
   - h5py =3.9  # When a version > 3.10 is used with tf 2.10: segmentation fault
   # testing

--- a/ci/envs/minimal.yml
+++ b/ci/envs/minimal.yml
@@ -12,7 +12,7 @@ dependencies:
   - python
   - pip
   # required
-  - gdal =3.7.0
+  - gdal =3.7  # 3.7.0 released 2023-05-03
   - gdown
   - geofileops =0.10
   - geopandas-base =1.0

--- a/ci/envs/minimal.yml
+++ b/ci/envs/minimal.yml
@@ -14,7 +14,7 @@ dependencies:
   # required
   - gdal =3.7.0
   - gdown
-  - geofileops =0.9
+  - geofileops =0.10
   - geopandas-base =1.0
   - matplotlib-base
   - numpy =1.26  # <2 is needed for tf < 2.18

--- a/ci/envs/readthedocs.yml
+++ b/ci/envs/readthedocs.yml
@@ -9,7 +9,7 @@ dependencies:
   # required
   - gdal
   - gdown
-  - geofileops >=0.9
+  - geofileops >=0.10
   - geopandas-base >=1.0
   - matplotlib-base
   - numpy

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -7,14 +7,14 @@ dependencies:
   # required
   - gdal
   - gdown
-  - geofileops >=0.6,<0.11
-  - geopandas-base >=0.12,<1.1
+  - geofileops >=0.10
+  - geopandas-base >=0.12
   - matplotlib-base
   - numpy
   - owslib
   - pillow
   - pycron
-  - pygeoops >=0.2,<0.5
+  - pygeoops >=0.2
   - pyproj
   - rasterio
   - shapely >=2

--- a/environment-gpu-win-dev.yml
+++ b/environment-gpu-win-dev.yml
@@ -7,14 +7,14 @@ dependencies:
   # required
   - gdal
   - gdown
-  - geofileops >=0.6,<0.11
-  - geopandas-base >=0.12,<1.1
+  - geofileops >=0.10
+  - geopandas-base >=0.12
   - matplotlib-base
   - numpy <2  # <2 is needed for tf < 2.18
   - owslib
   - pillow
   - pycron
-  - pygeoops >=0.2,<0.5
+  - pygeoops >=0.2
   - pyproj
   - rasterio
   - shapely >=2

--- a/orthoseg/lib/predicter.py
+++ b/orthoseg/lib/predicter.py
@@ -823,10 +823,11 @@ def _write_vector_result(
     # Copy the result to the main vector output file
     if vector_output_path is not None:
         if partial_vector_path.exists():
-            gfo.append_to(
+            gfo.copy_layer(
                 src=partial_vector_path,
                 dst=vector_output_path,
                 dst_layer=vector_output_path.stem,
+                write_mode="append",
                 create_spatial_index=False,
             )
             gfo.remove(partial_vector_path)

--- a/orthoseg/model/model_factory.py
+++ b/orthoseg/model/model_factory.py
@@ -22,7 +22,6 @@ import keras.models
 # Set the framework to use by segmentation_models to keras
 os.environ["SM_FRAMEWORK"] = "tf.keras"
 import segmentation_models
-from segmentation_models import Linknet, PSPNet, Unet
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -74,6 +73,8 @@ def get_model(
 
     if decoder.lower() == "unet":
         # Architecture implemented using the segmentation_models library
+        from segmentation_models import Unet  # noqa: PLC0415
+
         model = Unet(
             backbone_name=encoder.lower(),
             input_shape=(input_width, input_height, nb_channels),
@@ -86,6 +87,8 @@ def get_model(
 
     elif decoder.lower() == "pspnet":
         # Architecture implemented using the segmentation_models library
+        from segmentation_models import PSPNet  # noqa: PLC0415
+
         model = PSPNet(
             backbone_name=encoder.lower(),
             input_shape=(input_width, input_height, nb_channels),
@@ -101,6 +104,8 @@ def get_model(
         # First check if input size is compatible with linknet
         if input_width is not None and input_height is not None:
             check_image_size(architecture, input_width, input_height)
+
+        from segmentation_models import Linknet  # noqa: PLC0415
 
         model = Linknet(
             backbone_name=encoder.lower(),

--- a/orthoseg/model/model_factory.py
+++ b/orthoseg/model/model_factory.py
@@ -22,6 +22,7 @@ import keras.models
 # Set the framework to use by segmentation_models to keras
 os.environ["SM_FRAMEWORK"] = "tf.keras"
 import segmentation_models
+from segmentation_models import Linknet, PSPNet, Unet
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -73,8 +74,6 @@ def get_model(
 
     if decoder.lower() == "unet":
         # Architecture implemented using the segmentation_models library
-        from segmentation_models import Unet  # noqa: PLC0415
-
         model = Unet(
             backbone_name=encoder.lower(),
             input_shape=(input_width, input_height, nb_channels),
@@ -87,8 +86,6 @@ def get_model(
 
     elif decoder.lower() == "pspnet":
         # Architecture implemented using the segmentation_models library
-        from segmentation_models import PSPNet  # noqa: PLC0415
-
         model = PSPNet(
             backbone_name=encoder.lower(),
             input_shape=(input_width, input_height, nb_channels),
@@ -104,8 +101,6 @@ def get_model(
         # First check if input size is compatible with linknet
         if input_width is not None and input_height is not None:
             check_image_size(architecture, input_width, input_height)
-
-        from segmentation_models import Linknet  # noqa: PLC0415
 
         model = Linknet(
             backbone_name=encoder.lower(),

--- a/orthoseg/model/model_factory.py
+++ b/orthoseg/model/model_factory.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
 # Get a logger...
 logger = logging.getLogger(__name__)
+
 """
 preprocessing_fn = get_preprocessing('resnet34')
 x = preprocessing_fn(x)

--- a/orthoseg/model/model_factory.py
+++ b/orthoseg/model/model_factory.py
@@ -14,6 +14,7 @@ import os
 from pathlib import Path
 from typing import Any, TYPE_CHECKING
 
+import h5py
 import numpy as np
 import tensorflow as tf
 import keras.models
@@ -263,8 +264,6 @@ def load_model(model_to_use_filepath: Path, compile: bool = True) -> keras.model
 
                     # Ref: https://github.com/keras-team/keras/issues/19441
                     # Hack to change model config from keras 2->3 compliant
-                    import h5py  # noqa: PLC0415
-
                     f = h5py.File(str(model_to_use_filepath), mode="r+")
                     model_config_string = f.attrs.get("model_config")
                     if model_config_string.find('"groups": 1,') != -1:

--- a/orthoseg/model/model_factory.py
+++ b/orthoseg/model/model_factory.py
@@ -14,7 +14,6 @@ import os
 from pathlib import Path
 from typing import Any, TYPE_CHECKING
 
-import h5py
 import numpy as np
 import tensorflow as tf
 import keras.models
@@ -264,6 +263,8 @@ def load_model(model_to_use_filepath: Path, compile: bool = True) -> keras.model
 
                     # Ref: https://github.com/keras-team/keras/issues/19441
                     # Hack to change model config from keras 2->3 compliant
+                    import h5py  # noqa: PLC0415
+
                     f = h5py.File(str(model_to_use_filepath), mode="r+")
                     model_config_string = f.attrs.get("model_config")
                     if model_config_string.find('"groups": 1,') != -1:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     install_requires=[
         "gdal",
         "gdown",
-        "geofileops>=0.9",
+        "geofileops>=0.10",
         "geopandas>=1.0",
         "matplotlib",
         "numpy",


### PR DESCRIPTION
Replace `gfo.append_to` with `gfo.copy_layer` with `write_mode="append"` to avoid deprecation warning.

This needs minimum geofileops version 0.10 though, so update minimum dependency version as well.